### PR TITLE
ENS address resolution

### DIFF
--- a/autotx/agents/SwapTokensAgent.py
+++ b/autotx/agents/SwapTokensAgent.py
@@ -5,6 +5,7 @@ from pydantic import Field
 from autotx.AutoTx import AutoTx
 from autotx.auto_tx_agent import AutoTxAgent
 from autotx.auto_tx_tool import AutoTxTool
+from autotx.utils.ethereum.eth_address import ETHAddress
 from autotx.utils.ethereum.uniswap.swap import build_swap_transaction
 from autotx.utils.ethereum.config import contracts_config
 from gnosis.eth import EthereumClient
@@ -28,7 +29,7 @@ class ExecuteSwapTool(AutoTxTool):
                 in specifying the limits of token exchange rates and the adjustment of transaction parameters.
         """
     )
-    recipient: str | None = Field(None)
+    recipient: ETHAddress | None = Field(None)
     client: EthereumClient | None = Field(None)
 
     def __init__(self, autotx: AutoTx, client: EthereumClient, recipient: str):
@@ -53,7 +54,7 @@ class ExecuteSwapTool(AutoTxTool):
             amount,
             token_in_address,
             token_out_address,
-            self.recipient,
+            self.recipient.hex,
             is_exact_input,
         )
         self.autotx.transactions.extend(swap_transactions)
@@ -64,7 +65,7 @@ class ExecuteSwapTool(AutoTxTool):
             return f"Transaction to buy {amount} {token_out} with {token_in} has been prepared"
 
 class SwapTokensAgent(AutoTxAgent):
-    def __init__(self, autotx: AutoTx, client: EthereumClient, recipient: str):
+    def __init__(self, autotx: AutoTx, client: EthereumClient, recipient: ETHAddress):
         super().__init__(
             name="swap-tokens",
             role="Expert in swapping tokens",
@@ -73,7 +74,7 @@ class SwapTokensAgent(AutoTxAgent):
             tools=[ExecuteSwapTool(autotx, client, recipient)],
         )
 
-def build_agent_factory(client: EthereumClient, recipient: str) -> Callable[[AutoTx], Agent]:
+def build_agent_factory(client: EthereumClient, recipient: ETHAddress) -> Callable[[AutoTx], Agent]:
     def agent_factory(autotx: AutoTx) -> SwapTokensAgent:
         return SwapTokensAgent(autotx, client, recipient)
     return agent_factory

--- a/autotx/cli.py
+++ b/autotx/cli.py
@@ -2,6 +2,7 @@ import click
 from dotenv import load_dotenv
 
 from autotx.utils.ethereum.constants import SUPPORTED_NETWORKS
+from autotx.utils.ethereum.eth_address import ETHAddress
 from autotx.utils.ethereum.helpers.get_dev_account import get_dev_account
 load_dotenv()
 from autotx.agents import SendTokensAgent
@@ -66,7 +67,6 @@ def run(prompt: str, non_interactive: bool):
 
     print("Final smart account balances:")
     show_address_balances(web3, network_info, manager.address)
-    show_address_balances(web3, network_info, "0x7C418D7083f6c22B3d600B8fe4F0cf93564098dD")
 
 @main.group()
 def agent():
@@ -105,8 +105,10 @@ def agent_account_info():
     print(f"Chain ID: {chain_id}")
     network_info = SUPPORTED_NETWORKS.get(chain_id)
 
-    print(f"Agent address: {agent.address}")
-    show_address_balances(web3, network_info, agent.address)
+    agent_address = ETHAddress(agent.address, web3)
+
+    print(f"Agent address: {agent_address}")
+    show_address_balances(web3, network_info, agent_address)
 
 if __name__ == "__main__":
     main()

--- a/autotx/tests/conftest.py
+++ b/autotx/tests/conftest.py
@@ -2,6 +2,7 @@ from dotenv import load_dotenv
 
 from autotx.utils.ethereum.cached_safe_address import delete_cached_safe_address
 from autotx.utils.ethereum.constants import SUPPORTED_NETWORKS
+from autotx.utils.ethereum.eth_address import ETHAddress
 from autotx.utils.ethereum.helpers.get_dev_account import get_dev_account
 
 load_dotenv()
@@ -55,7 +56,7 @@ def auto_tx(configuration):
     ], None)
 
 @pytest.fixture()
-def mock_erc20(configuration):
+def mock_erc20(configuration) -> ETHAddress:
     (user, _, client, manager) = configuration
     mock_erc20 = deploy_mock_erc20(client.w3, user)
     transfer_tx = transfer_erc20(
@@ -66,6 +67,6 @@ def mock_erc20(configuration):
     chain_id = client.w3.eth.chain_id
     network = SUPPORTED_NETWORKS.get(chain_id)
 
-    network.tokens["tt"] = mock_erc20
+    network.tokens["tt"] = mock_erc20.hex
 
     return mock_erc20

--- a/autotx/tests/integration/test_swap.py
+++ b/autotx/tests/integration/test_swap.py
@@ -1,29 +1,31 @@
 from autotx.utils.ethereum import (
     get_erc20_balance,
 )
+from autotx.utils.ethereum.constants import SUPPORTED_NETWORKS
+from autotx.utils.ethereum.eth_address import ETHAddress
 from autotx.utils.ethereum.uniswap.swap import build_swap_transaction
-from autotx.utils.ethereum.helpers.show_address_balances import (
-    weth_address,
-    usdc_address,
-    wbtc_address,
-)
-
 
 def test_swap(configuration):
     (user, _, client, _) = configuration
 
-    balance = get_erc20_balance(client.w3, wbtc_address, user.address)
+    network_info = SUPPORTED_NETWORKS.get(client.w3.eth.chain_id)
+    weth_address = ETHAddress(network_info.tokens["weth"], client.w3)
+    wbtc_address = ETHAddress(network_info.tokens["wbtc"], client.w3)
+
+    user_addr =  ETHAddress(user.address, client.w3)
+
+    balance = get_erc20_balance(client.w3, wbtc_address, user_addr)
     assert balance == 0
 
     txs = build_swap_transaction(
-        client, 0.05, weth_address, wbtc_address, user.address, False
+        client, 0.05, weth_address.hex, wbtc_address.hex, user_addr.hex, False
     )
 
     for i, tx in enumerate(txs):
         transaction = user.sign_transaction(
             {
-                **tx,
-                "nonce": client.w3.eth.get_transaction_count(user.address),
+                **tx.tx,
+                "nonce": client.w3.eth.get_transaction_count(user_addr.hex),
                 "gas": 200000,
             }
         )
@@ -36,21 +38,25 @@ def test_swap(configuration):
             print(f"Transaction #{i} failed ")
             break
 
-    new_balance = get_erc20_balance(client.w3, wbtc_address, user.address)
+    new_balance = get_erc20_balance(client.w3, wbtc_address, user_addr)
     assert new_balance == 0.05 * 10**8
 
 
 def test_swap_through_safe(configuration):
     (_, _, client, manager) = configuration
+    
+    network_info = SUPPORTED_NETWORKS.get(client.w3.eth.chain_id)
+    weth_address = ETHAddress(network_info.tokens["weth"], client.w3)
+    usdc_address = ETHAddress(network_info.tokens["usdc"], client.w3)
 
     balance = manager.balance_of(usdc_address)
     assert balance == 0
 
     txs = build_swap_transaction(
-        client, 6000, weth_address, usdc_address, manager.address, False
+        client, 6000, weth_address.hex, usdc_address.hex, manager.address.hex, False
     )
 
-    hash = manager.send_tx_batch(txs)
+    hash = manager.send_tx_batch(txs, require_approval=False)
     manager.wait(hash)
 
     new_balance = manager.balance_of(usdc_address)

--- a/autotx/tests/test_tokens.py
+++ b/autotx/tests/test_tokens.py
@@ -1,13 +1,14 @@
 from autotx.patch import patch_langchain
 from autotx.utils.ethereum import get_erc20_balance, load_w3
 from autotx.utils.ethereum.constants import SUPPORTED_NETWORKS
+from autotx.utils.ethereum.eth_address import ETHAddress
 from autotx.utils.ethereum.get_eth_balance import get_eth_balance
 
 patch_langchain()
 
 def test_auto_tx_send_eth(configuration, auto_tx):
     (_, _, client, _) = configuration
-    reciever = "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
+    reciever = ETHAddress("0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1", client.w3)
     balance = get_eth_balance(client.w3, reciever)
     assert balance == 0
 
@@ -18,7 +19,7 @@ def test_auto_tx_send_eth(configuration, auto_tx):
 
 def test_auto_tx_send_eth_twice(configuration, auto_tx, mock_erc20):
     (_, _, client, _) = configuration
-    reciever = "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
+    reciever = ETHAddress("0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1", client.w3)
 
     balance = get_erc20_balance(client.w3, mock_erc20, reciever)
     assert balance == 0
@@ -66,7 +67,7 @@ def test_auto_tx_swap(configuration, auto_tx):
 def test_auto_tx_send_erc20(configuration, auto_tx, mock_erc20):
     (_, _, client, _) = configuration
 
-    reciever = "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
+    reciever = ETHAddress("0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1", client.w3)
 
     prompts = [
         f"Send 10 TT to {reciever}",
@@ -95,8 +96,8 @@ def test_auto_tx_send_erc20(configuration, auto_tx, mock_erc20):
 def test_auto_tx_multiple_sends(configuration, auto_tx, mock_erc20):
     (_, _, client, _) = configuration
 
-    reciever_one = "0x10f8Bf6a479F320ead074411A4b0e7944eA8C9c1"
-    reciever_two = "0x20f8Bf6a479F320EaD074411a4b0e7944eA8c9C1"
+    reciever_one = ETHAddress("0x10f8Bf6a479F320ead074411A4b0e7944eA8C9c1", client.w3)
+    reciever_two = ETHAddress("0x20f8Bf6a479F320EaD074411a4b0e7944eA8c9C1", client.w3)
 
     prompts = [
         f"Send 10 TT to {reciever_one} and 20 TT to {reciever_two}",
@@ -131,7 +132,7 @@ def test_auto_tx_swap_and_send(configuration, auto_tx):
     usdc_address = network_info.tokens["usdc"]
     wbtc_address = network_info.tokens["wbtc"]
 
-    reciever = "0x10f8Bf6a479F320ead074411A4b0e7944eA8C9c1"
+    reciever = ETHAddress("0x10f8Bf6a479F320ead074411A4b0e7944eA8C9c1", client.w3)
 
     prompts = [
         f"Swap ETH to 0.05 WBTC, then, swap WBTC to 1000 USDC and send 50 USDC to {reciever}",

--- a/autotx/utils/agent/build_goal.py
+++ b/autotx/utils/agent/build_goal.py
@@ -4,6 +4,8 @@ import typing
 
 import openai
 
+from autotx.utils.ethereum.eth_address import ETHAddress
+
 class GoalResponse:
     goal: str
     type: str = "goal"
@@ -27,7 +29,7 @@ class InvalidPromptResponse:
 
 DefineGoalResponse = typing.Union[GoalResponse, MissingInfoResponse, InvalidPromptResponse]
 
-def get_persona(smart_account_address: str) -> str:
+def get_persona(smart_account_address: ETHAddress) -> str:
     return dedent(
         f"""
         You are an AI assistant that helps the user define goals and tasks for your agents. 
@@ -36,7 +38,7 @@ def get_persona(smart_account_address: str) -> str:
         """
     )
 
-def build_goal(prompt: str, agents_information: str, smart_account_address: str, non_interactive: bool) -> str:
+def build_goal(prompt: str, agents_information: str, smart_account_address: ETHAddress, non_interactive: bool) -> str:
     response: DefineGoalResponse | None = None
     chat_history = f"User: {prompt}"
 
@@ -61,7 +63,7 @@ def build_goal(prompt: str, agents_information: str, smart_account_address: str,
         elif response.type == "goal":
             return response.goal
 
-def analyze_user_prompt(chat_history: str, agents_information: str, smart_account_address: str) -> DefineGoalResponse:
+def analyze_user_prompt(chat_history: str, agents_information: str, smart_account_address: ETHAddress) -> DefineGoalResponse:
     template = dedent(
         """
         Based on the following chat history between you and the user: 

--- a/autotx/utils/configuration.py
+++ b/autotx/utils/configuration.py
@@ -5,6 +5,7 @@ from eth_account import Account
 
 from autotx.utils.ethereum.agent_account import get_or_create_agent_account
 from autotx.utils.ethereum.constants import FORK_RPC_URL
+from autotx.utils.ethereum.eth_address import ETHAddress
 
 smart_account_addr = get_env_vars()
 
@@ -12,4 +13,6 @@ def get_configuration():
     client = EthereumClient(URI(FORK_RPC_URL))
     agent: Account = get_or_create_agent_account()
 
-    return (smart_account_addr, agent, client)
+    smart_account = ETHAddress(smart_account_addr, client.w3) if smart_account_addr else None
+
+    return (smart_account, agent, client)

--- a/autotx/utils/ethereum/__init__.py
+++ b/autotx/utils/ethereum/__init__.py
@@ -15,7 +15,6 @@ from .load_w3 import load_w3
 from .build_approve_erc20 import build_approve_erc20
 from .get_erc20_info import get_erc20_info
 from .is_valid_safe import is_valid_safe
-from .get_address import get_address
 
 __all__ = [
     "get_eth_balance",
@@ -30,7 +29,6 @@ __all__ = [
     "build_transfer_eth",
     "build_transfer_erc20",
     "build_approve_erc20",
-    "get_address",
     "get_erc20_balance",
     "get_erc20_info",
     "SafeManager",

--- a/autotx/utils/ethereum/build_approve_erc20.py
+++ b/autotx/utils/ethereum/build_approve_erc20.py
@@ -1,14 +1,12 @@
 from web3 import Web3
 from web3.types import TxParams
-from autotx.utils.ethereum.get_address import get_address
+from autotx.utils.ethereum.eth_address import ETHAddress
 from autotx.utils.ethereum.mock_erc20 import MOCK_ERC20_ABI
 
-def build_approve_erc20(web3: Web3, token_address: str, spender: str, value: float):
-    spender = get_address(web3, spender)
-
-    erc20 = web3.eth.contract(address=token_address, abi=MOCK_ERC20_ABI)
+def build_approve_erc20(web3: Web3, token_address: ETHAddress, spender: ETHAddress, value: float):
+    erc20 = web3.eth.contract(address=token_address.hex, abi=MOCK_ERC20_ABI)
     decimals = erc20.functions.decimals().call()
 
-    tx: TxParams = erc20.functions.approve(spender, int(value * 10 ** decimals)).build_transaction()
+    tx: TxParams = erc20.functions.approve(spender.hex, int(value * 10 ** decimals)).build_transaction()
 
     return tx

--- a/autotx/utils/ethereum/build_transfer_erc20.py
+++ b/autotx/utils/ethereum/build_transfer_erc20.py
@@ -1,15 +1,15 @@
 from web3 import Web3
 from web3.types import TxParams
-from .get_address import get_address
+
+from autotx.utils.ethereum.eth_address import ETHAddress
 from .constants import GAS_PRICE_MULTIPLIER
 from .mock_erc20 import MOCK_ERC20_ABI
 
-def build_transfer_erc20(web3: Web3, token_address: str, to: str, value: float):
-    to = get_address(web3, to)
+def build_transfer_erc20(web3: Web3, token_address: str, to: ETHAddress, value: float):
     erc20 = web3.eth.contract(address=token_address, abi=MOCK_ERC20_ABI)
     decimals = erc20.functions.decimals().call()
     tx: TxParams = erc20.functions.transfer(
-        to, int(value * 10**decimals)
+        to.hex, int(value * 10**decimals)
     ).build_transaction(
         {"gas": None, "gasPrice": web3.eth.gas_price * GAS_PRICE_MULTIPLIER}
     )

--- a/autotx/utils/ethereum/build_transfer_eth.py
+++ b/autotx/utils/ethereum/build_transfer_eth.py
@@ -1,13 +1,12 @@
 from web3 import Web3
 from web3.types import TxParams
-from .get_address import get_address
 
-def build_transfer_eth(web3: Web3, from_address: str, to: str, value: float) -> TxParams:
-    to = get_address(web3, to)
-    from_address = get_address(web3, from_address)
+from autotx.utils.ethereum.eth_address import ETHAddress
+
+def build_transfer_eth(web3: Web3, from_address: ETHAddress, to: ETHAddress, value: float) -> TxParams:
     return {
-        "to": to,
+        "to": to.hex,
         "value": web3.to_wei(value, "ether"),
         "data": b"",
-        "from": from_address,
+        "from": from_address.hex,
     }

--- a/autotx/utils/ethereum/deploy_mock_erc20.py
+++ b/autotx/utils/ethereum/deploy_mock_erc20.py
@@ -1,11 +1,12 @@
 from eth_account import Account
 from web3 import Web3
-from web3.types import TxParams
 from web3.middleware import construct_sign_and_send_raw_middleware
+
+from autotx.utils.ethereum.eth_address import ETHAddress
 
 from .mock_erc20 import MOCK_ERC20_ABI, MOCK_ERC20_BYTECODE
 
-def deploy_mock_erc20(web3: Web3, account: Account) -> str:
+def deploy_mock_erc20(web3: Web3, account: Account) -> ETHAddress:
     account_middleware = construct_sign_and_send_raw_middleware(account)
     web3.middleware_onion.add(account_middleware)
     MockERC20 = web3.eth.contract(abi=MOCK_ERC20_ABI, bytecode=MOCK_ERC20_BYTECODE)
@@ -18,4 +19,4 @@ def deploy_mock_erc20(web3: Web3, account: Account) -> str:
 
     web3.middleware_onion.remove(account_middleware)
 
-    return receipt.contractAddress
+    return ETHAddress(receipt.contractAddress, web3)

--- a/autotx/utils/ethereum/deploy_multicall.py
+++ b/autotx/utils/ethereum/deploy_multicall.py
@@ -3,15 +3,17 @@ from eth_account import Account
 from gnosis.eth import EthereumClient
 from gnosis.eth.multicall import Multicall
 
+from autotx.utils.ethereum.eth_address import ETHAddress
+
 from .cache import cache
 
-def  deploy_multicall(client: EthereumClient, account: Account) -> str:
+def deploy_multicall(client: EthereumClient, account: Account) -> ETHAddress:
     if os.getenv("MULTICALL_ADDRESS"):
         return os.getenv("MULTICALL_ADDRESS")
 
     address = cache(lambda: deploy(client, account), "./.cache/multicall-address.txt")
 
-    return address
+    return ETHAddress(address, client.w3)
 
 def deploy(client: EthereumClient, account: Account) -> str:
     tx =  Multicall.deploy_contract(client, account) 

--- a/autotx/utils/ethereum/eth_address.py
+++ b/autotx/utils/ethereum/eth_address.py
@@ -1,0 +1,18 @@
+from web3 import Web3
+
+class ETHAddress:
+    hex: str
+    ens_domain: str | None
+
+    def __init__(self, hex_or_ens: str, web3: Web3):
+        if hex_or_ens.endswith(".eth"):
+            self.hex = web3.ens.address(hex_or_ens)
+            self.ens_domain = hex_or_ens
+        elif Web3.is_address(hex_or_ens):
+            self.hex = Web3.to_checksum_address(hex_or_ens)
+            self.ens_domain = None
+        else:
+            raise ValueError(f"Invalid address: {hex_or_ens}")
+        
+    def __repr__(self) -> str:
+        return f"{self.ens_domain}({self.hex})" if self.ens_domain else self.hex

--- a/autotx/utils/ethereum/get_address.py
+++ b/autotx/utils/ethereum/get_address.py
@@ -1,7 +1,0 @@
-from web3 import Web3
-
-def get_address(web3: Web3, address: str) -> str:
-    if address.endswith(".eth"):
-        return web3.ens.address(address) or address
-    else:
-        return address

--- a/autotx/utils/ethereum/get_erc20_balance.py
+++ b/autotx/utils/ethereum/get_erc20_balance.py
@@ -1,8 +1,8 @@
 from web3 import Web3
-from .mock_erc20 import MOCK_ERC20_ABI
-from .get_address import get_address
 
-def get_erc20_balance(web3: Web3, token_address: str, account: str) -> int:
-    MockERC20 = web3.eth.contract(address=Web3.to_checksum_address(token_address), abi=MOCK_ERC20_ABI)
-    account = get_address(web3, account)
-    return MockERC20.functions.balanceOf(account).call()
+from autotx.utils.ethereum.eth_address import ETHAddress
+from .mock_erc20 import MOCK_ERC20_ABI
+
+def get_erc20_balance(web3: Web3, token_address: ETHAddress, account: ETHAddress) -> int:
+    MockERC20 = web3.eth.contract(address=Web3.to_checksum_address(token_address.hex), abi=MOCK_ERC20_ABI)
+    return MockERC20.functions.balanceOf(account.hex).call()

--- a/autotx/utils/ethereum/get_erc20_info.py
+++ b/autotx/utils/ethereum/get_erc20_info.py
@@ -1,8 +1,10 @@
 from web3 import Web3
+
+from autotx.utils.ethereum.eth_address import ETHAddress
 from .mock_erc20 import MOCK_ERC20_ABI
 
-def get_erc20_info(web3: Web3, token_address: str) -> tuple[str, str, int]:
-    MockERC20 = web3.eth.contract(address=token_address, abi=MOCK_ERC20_ABI)
+def get_erc20_info(web3: Web3, token_address: ETHAddress) -> tuple[str, str, int]:
+    MockERC20 = web3.eth.contract(address=token_address.hex, abi=MOCK_ERC20_ABI)
 
     name = MockERC20.functions.name().call()
     symbol = MockERC20.functions.symbol().call()

--- a/autotx/utils/ethereum/get_eth_balance.py
+++ b/autotx/utils/ethereum/get_eth_balance.py
@@ -1,4 +1,6 @@
 from web3 import Web3
 
-def get_eth_balance(web3: Web3, address: str) -> int: 
-    return web3.eth.get_balance(address)
+from autotx.utils.ethereum.eth_address import ETHAddress
+
+def get_eth_balance(web3: Web3, address: ETHAddress) -> int: 
+    return web3.eth.get_balance(address.hex)

--- a/autotx/utils/ethereum/helpers/show_address_balances.py
+++ b/autotx/utils/ethereum/helpers/show_address_balances.py
@@ -2,13 +2,14 @@ from web3 import Web3
 
 from autotx.utils.ethereum import get_erc20_balance
 from autotx.utils.ethereum.constants import NetworkInfo
+from autotx.utils.ethereum.eth_address import ETHAddress
 
-def show_address_balances(web3: Web3, network: NetworkInfo, address: str):
-    eth_balance = web3.eth.get_balance(Web3.to_checksum_address(address))
+def show_address_balances(web3: Web3, network: NetworkInfo, address: ETHAddress):
+    eth_balance = web3.eth.get_balance(address.hex)
     print(f"ETH balance: {eth_balance / 10 ** 18}")
 
     tokens = network.tokens
     for token in tokens:
-        token_address = tokens[token]
+        token_address = ETHAddress(tokens[token], web3)
         balance = get_erc20_balance(web3, token_address, address)
         print(f"{token.upper()} balance: {balance / 10 ** 18}")

--- a/autotx/utils/ethereum/is_valid_safe.py
+++ b/autotx/utils/ethereum/is_valid_safe.py
@@ -1,13 +1,15 @@
 from gnosis.eth import EthereumClient
 from web3 import Web3
 from gnosis.safe import Safe
+
+from autotx.utils.ethereum.eth_address import ETHAddress
 from .constants import MASTER_COPY_ADDRESS
 
-def is_valid_safe(client: EthereumClient, safe_address: str) -> bool:
+def is_valid_safe(client: EthereumClient, safe_address: ETHAddress) -> bool:
     w3 = client.w3
 
-    if w3.eth.get_code(Web3.to_checksum_address(safe_address)) != w3.to_bytes(hexstr="0x"):
-        safe = Safe(Web3.to_checksum_address(safe_address), client)
+    if w3.eth.get_code(Web3.to_checksum_address(safe_address.hex)) != w3.to_bytes(hexstr="0x"):
+        safe = Safe(Web3.to_checksum_address(safe_address.hex), client)
         master_copy_address = safe.retrieve_master_copy_address()
         return master_copy_address == MASTER_COPY_ADDRESS
     else:

--- a/autotx/utils/ethereum/send_eth.py
+++ b/autotx/utils/ethereum/send_eth.py
@@ -4,16 +4,18 @@ from web3 import Web3
 from web3.types import TxReceipt
 from web3.types import TxParams
 
+from autotx.utils.ethereum.eth_address import ETHAddress
+
 from .constants import GAS_PRICE_MULTIPLIER
 
-def send_eth(account: Account, to: str, value: float, web3: Web3) -> tuple[str, TxReceipt]:
+def send_eth(account: Account, to: ETHAddress, value: float, web3: Web3) -> tuple[str, TxReceipt]:
     bytes_address: Address = Address(bytes.fromhex(account.address[2:]))
 
     nonce = web3.eth.get_transaction_count(bytes_address)
 
     tx: TxParams = {
         'from': account.address,
-        'to': to,
+        'to': to.hex,
         'value': int(value * 10 ** 18),
         'gasPrice': int(web3.eth.gas_price * GAS_PRICE_MULTIPLIER),
         'nonce': nonce,

--- a/autotx/utils/ethereum/transfer_erc20.py
+++ b/autotx/utils/ethereum/transfer_erc20.py
@@ -2,21 +2,20 @@ from eth_account import Account
 from web3 import Web3
 from web3.middleware import construct_sign_and_send_raw_middleware
 
-from autotx.utils.ethereum.get_address import get_address
+from autotx.utils.ethereum.eth_address import ETHAddress
+
 from .constants import GAS_PRICE_MULTIPLIER
 
 from .mock_erc20 import MOCK_ERC20_ABI
 
-def transfer_erc20(web3: Web3, token_address: str, from_account: Account, to: str, value: float):
+def transfer_erc20(web3: Web3, token_address: ETHAddress, from_account: Account, to: ETHAddress, value: float):
     account_middleware = construct_sign_and_send_raw_middleware(from_account)
     web3.middleware_onion.add(account_middleware)
 
-    to = get_address(web3, to)
-   
-    erc20 = web3.eth.contract(address=token_address, abi=MOCK_ERC20_ABI)
+    erc20 = web3.eth.contract(address=token_address.hex, abi=MOCK_ERC20_ABI)
     decimals = erc20.functions.decimals().call()
 
-    tx_hash = erc20.functions.transfer(to, int(value * 10 ** decimals)).transact({"from": from_account.address, "gasPrice": int(web3.eth.gas_price * GAS_PRICE_MULTIPLIER)})
+    tx_hash = erc20.functions.transfer(to.hex, int(value * 10 ** decimals)).transact({"from": from_account.address, "gasPrice": int(web3.eth.gas_price * GAS_PRICE_MULTIPLIER)})
 
     web3.middleware_onion.remove(account_middleware)
 


### PR DESCRIPTION
Closes #67 

**Notes**
- `ETHAddress` class can now be used to refer to either a hex address or an ens domain
- Constructing an `ETHAddress` immediately resolves the ens domain if provided
- Use `.hex` for the hex value of the address
- Use `.ens_domain` for the domain name (if it exists)
- Implements `__repr__` so it can be directly printed or convert to string with `str(addr)`