### PR TITLE
fix: .env.example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please install the following:
 
 ## Installation
 1. Clone the repository via `git clone https://github.com/polywrap/AutoTx` and `cd AutoTx` into the directory.
-2. Create a new .env file via `cp .env.template .env`
+2. Create a new .env file via `cp .env.example .env`
 3. Find the line that says OPENAI_API_KEY=, and add your unique OpenAI API Key `OPENAI_API_KEY=sk-...`
 4. Find the line that says CHAIN_RPC_URL=, and add your unique Ethereum RPC URL `CHAIN_RPC_URL=https://mainnet.infura.io/v3/...` (see https://www.infura.io/)
 5. Start a new poetry shell `poetry shell`


### PR DESCRIPTION
Will work on Readme updates here