### PR TITLE
Improved agent prompting

### DIFF
--- a/autotx/agents/SwapTokensAgent.py
+++ b/autotx/agents/SwapTokensAgent.py
@@ -21,6 +21,8 @@ class ExecuteSwapExactInTool(AutoTxTool):
             to needed decimals.
             token_in (str): Symbol of token input.
             token_out (str): Symbol of token output.
+        Returns:
+            str: A confirmation message that the transaction to swap tokens has been prepared
         """
     )
     recipient: ETHAddress | None = Field(None)
@@ -73,6 +75,8 @@ class ExecuteSwapExactOutTool(AutoTxTool):
             to needed decimals.
             token_in (str): Symbol of token input.
             token_out (str): Symbol of token output.
+        Returns:
+            str: A confirmation message that the transaction to swap tokens has been prepared
         """
     )
     recipient: ETHAddress | None = Field(None)


### PR DESCRIPTION
```
Run from: ./autotx/tests/token/send
Iterations: 5
==================================================
Test Name	Success Rate	Passes	Fails	Avg Time
==================================================
autotx/tests/token/send/test_send.py::test_auto_tx_send_eth	100%	5	0	44s
autotx/tests/token/send/test_send.py::test_auto_tx_send_erc20	0%	0	5	22s
autotx/tests/token/send/test_send.py::test_auto_tx_send_eth_sequential	60%	3	2	1.16m
autotx/tests/token/send/test_send.py::test_auto_tx_send_erc20_parallel	80%	4	1	45s
autotx/tests/token/send/test_send_with_tasks.py::test_send_tokens_agent	100%	5	0	28s
autotx/tests/token/send/test_send_with_tasks.py::test_send_tokens_agent_with_check	100%	5	0	30s
autotx/tests/token/send/test_send_with_tasks.py::test_send_tokens_agent_with_check2	100%	5	0	29s
Total run time: 22.15 minutes
```
The erc20 0% results were troubling, but it turns out 3 of them are the agent not recognizing TTOK token, one was a hallucination of response and one was hallucination of reciever 
