### PR TITLE
fix: properly emit the transaction summaries

### DIFF
--- a/autotx/agents/SwapTokensAgent.py
+++ b/autotx/agents/SwapTokensAgent.py
@@ -98,15 +98,16 @@ class SwapTool(AutoTxTool):
             )
             autotx.transactions.extend(swap_transactions)
 
-            token_in_amount = f"{exact_amount} " if is_exact_input else ""
-            token_out_amount = f"{exact_amount} " if not is_exact_input else ""
+            summary = "".join(
+                f"Prepared transaction: {swap_transaction.summary}\n"
+                for swap_transaction in swap_transactions
+            )
 
-            print(f"Prepared transaction: Buy {token_out_amount}{token_out} with {token_in_amount}{token_in}")
-
-            return f"Transaction to buy {token_out_amount}{token_out} with {token_in_amount}{token_in} has been prepared"
+            print(summary)
+            return summary
 
         return run
-    
+
 class SwapTokensAgent(AutoTxAgent):
     name = name
     system_message = system_message


### PR DESCRIPTION
This fix is needed for prompts like `Buy 1 ETH of the highest mcap AI token on ethereum mainnet, then airdrop it to: vitalik.eth, abc.eth, and maxi.eth`. This is because, in the old implementation, the amount of tokens bought with 1 ETH was not being emitted to the group chat's context. With the changes in this PR the group chat can see exactly how much output token is being purchased.