### PR TITLE
fix: withdraw weth

### DIFF
--- a/autotx/utils/ethereum/uniswap/swap.py
+++ b/autotx/utils/ethereum/uniswap/swap.py
@@ -113,11 +113,12 @@ def build_swap_transaction(
 
     token_in = web3.eth.contract(
         address=uniswap.weth_address if token_in_is_native else web3.to_checksum_address(token_in_address),
-        abi=WETH_ABI if token_in_address == uniswap.weth_address else ERC20_ABI,
+        abi=WETH_ABI if token_in_address == uniswap.weth_address or token_in_is_native else ERC20_ABI,
     )
+
     token_out = web3.eth.contract(
         address=uniswap.weth_address if token_out_is_native else web3.to_checksum_address(token_out_address),
-        abi=WETH_ABI if token_out_address == uniswap.weth_address else ERC20_ABI,
+        abi=WETH_ABI if token_out_address == uniswap.weth_address or token_out_is_native else ERC20_ABI,
     )
 
     transactions: list[PreparedTx] = []


### PR DESCRIPTION
swap from ERC20 to `ETH` is not working because we're just checking if the address of the out token is `WETH`