### PR TITLE
chore: add `process_message_before_send` hook to autotx agents

### DIFF
--- a/autotx/AutoTx.py
+++ b/autotx/AutoTx.py
@@ -117,7 +117,10 @@ class AutoTx:
                 silent: bool
             ) -> Union[Dict[str, Any], str]:
                 if recipient.name == "chat_manager" and message != "TERMINATE":
-                    cprint(message if isinstance(message, str) else message["content"])
+                    if isinstance(message, str):
+                        cprint(message, "light_yellow")
+                    elif message["content"] != None:
+                        cprint(message["content"], "light_yellow")
                 return message
 
             verifier_agent.register_hook(

--- a/autotx/autotx_agent.py
+++ b/autotx/autotx_agent.py
@@ -1,5 +1,6 @@
-from typing import Any, Callable, Dict, Optional, TYPE_CHECKING
+from typing import Any, Callable, Dict, Optional, TYPE_CHECKING, Union
 import autogen
+from termcolor import cprint
 if TYPE_CHECKING:
     from autotx.autotx_tool import AutoTxTool
     from autotx.AutoTx import AutoTx
@@ -29,6 +30,26 @@ class AutoTxAgent():
             llm_config=llm_config,
             human_input_mode="NEVER",
             code_execution_config=False,
+        )
+
+        # Print all messages sent form the verifier to the group chat manager,
+        # as they tend to contain valuable information
+        def send_message_hook(
+            sender: autogen.AssistantAgent,
+            message: Union[Dict[str, Any], str],
+            recipient: autogen.Agent,
+            silent: bool,
+        ) -> Union[Dict[str, Any], str]:
+            if recipient.name == "chat_manager" and message != "TERMINATE":
+                if isinstance(message, str):
+                    cprint(message, "light_yellow")
+                elif message["content"] != None:
+                    cprint(message["content"], "light_yellow")
+            return message
+
+        agent.register_hook(
+            "process_message_before_send",
+            send_message_hook
         )
 
         for tool in self.tools:


### PR DESCRIPTION
now agents message to the manager are shown in light-yellow, improving the logs of whats happening under the hood

examples:
![image](https://github.com/polywrap/AutoTx/assets/21031138/b6049be4-2ba7-4b8e-ba1f-a30108f5df2e)

![image](https://github.com/polywrap/AutoTx/assets/21031138/f3a8ba0b-f868-4a05-a841-528c425043d7)
