### PR TITLE
feat: improved user_proxy which helps direct agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ AutoTx currently supports prompts such as:
 | Multi Task| `Swap ETH to 0.05 WBTC, then swap WBTC to 1000 USDC, and finally send 50 USDC to vitalik.eth` |
 | Multi Task, Airdrop | `Buy 10 WLD with ETH, then send the WLD in equal amounts to each of these addresses: vitalik.eth, abc.eth, and maxi.eth` |
 | Multi Task, Airdrop | `Buy 1 ETH of the highest mcap meme coin on ethereum mainnet, then airdrop it in equal parts to: vitalik.eth, abc.eth, and maxi.eth` |
+| Multi Task, Strategy | `I want to use 3 ETH to purchase 10 of the best projects in: GameFi, NFTs, ZK, AI, and MEMEs. Please research the top projects, come up with a strategy, and purchase the tokens that look most promising. All of this should be on ETH mainnet.` |
 
 Future possibilities:
 * `Purchase mainnet ETH with my USDC on optimism`

--- a/autotx/AutoTx.py
+++ b/autotx/AutoTx.py
@@ -74,33 +74,40 @@ class AutoTx:
 
             print("Running AutoTx with the following prompt: ", prompt)
 
+            agents_information = self.get_agents_information(self.agents)
+
+            goal = build_goal(prompt, agents_information, self.manager.address, self.network.chain_id.name, non_interactive)
+
             user_proxy = UserProxyAgent(
                 name="user_proxy",
                 is_termination_msg=lambda x: x.get("content", "") and x.get("content", "").rstrip().endswith("TERMINATE"),
                 human_input_mode="NEVER",
                 max_consecutive_auto_reply=20,
-                system_message=f"You are a user proxy. You will be interacting with the agents to accomplish the tasks.",
+                system_message=dedent(
+                    f"""
+                    You are the user, you never ask for permission, you have ultimate control.
+                    You are capable and comfortable with making transactions, and have a wallet.
+                    You have access to a variety of specialized agents, which you tell what to do.
+
+                    These are the agents you are instructing: {agents_information}
+
+                    Suggest a next step for what these agents should do based on the goal: "{goal}"
+                    """
+                ),
                 llm_config=self.get_llm_config(),
                 code_execution_config=False,
             )
-
-            agents_information = self.get_agents_information(self.agents)
-
-            goal = build_goal(prompt, agents_information, self.manager.address, self.network.chain_id.name, non_interactive)
 
             verifier_agent = AssistantAgent(
                 name="verifier",
                 is_termination_msg=lambda x: x.get("content", "") and x.get("content", "").rstrip().endswith("TERMINATE"),
                 system_message=dedent(
-                        """
-                        Verifier is an expert in verifiying if user goals are met.
-                        Verifier analyzes chat and responds with TERMINATE if the goal is met.
-                        Verifier can consider the goal met if the other agents have prepared the necessary transactions.
-                        
-                        If some information needs to be returned to the user or if there are any errors encountered during the process, add this in your answer.
-                        Start any error messages with "ERROR:" to clearly indicate the issue. Then say the word TERMINATE.
-                        Make sure to only add information if the user explicitly asks for a question that needs to be answered
-                        or error details if user's request can not be completed.
+                    """
+                    Verifier is an expert in verifiying if user goals are met.
+                    Verifier analyzes chat and responds with TERMINATE if the goal is met.
+                    Verifier can consider the goal met if the other agents have prepared the necessary transactions.
+                    Let the other agents complete all the necessary parts of the goal before calling TERMINATE.
+                    If you find the conversation is repeating and no new progress is made, TERMINATE.
                     """
                     ),
                 llm_config=self.get_llm_config(),
@@ -137,6 +144,7 @@ class AutoTx:
                 select_speaker_prompt_template = (
                     """
                     Read the above conversation. Then select the next role from {agentlist} to play. Only return the role and NOTHING else.
+                    If agents are trying to communicate with the user, or requesting approval, return the 'user_proxy' role.
                     """
                 )
             )

--- a/autotx/agents/ResearchTokensAgent.py
+++ b/autotx/agents/ResearchTokensAgent.py
@@ -18,7 +18,8 @@ system_message = lambda autotx: dedent(f"""
     You are an AI assistant. Assist the user (address: {autotx.manager.address}) in their task of researching tokens.
     You are an expert in Ethereum tokens and can help users research tokens.
     You use the tools available to assist the user in their tasks.
-    Retrieve token information, get token price, market cap, and price change percentage
+    Retrieve token information, get token price, market cap, and price change percentage.
+    Always fetch available token categories before suggesting names, do not make them up.
     """
 )
 


### PR DESCRIPTION
Changes:
* `user_proxy` now assumes the role of the user, and is responsible for answer any queries other agents may have. This solves the problem of agents requesting user permission to proceed. Additionally the `user_proxy` has knowledge of these agents and their capabilities so it can help suggest the best next step to take to solve for the user's goal.
* The `verifier` no longer `TERMINATE`s if an error is encountered, nor does it check for missing information. Its sole responsibility should be to verify if the is being achieved. It does this through checking for completion, and also watching for circular conversations that lead to no progress being made.
* The `group_chat` now selects the `user_proxy` role if other agents are trying to communicate with the user or request approval.

Additional:
* fix: ResearchAgent fetches available categories before suggesting

With these fixes, I was able to achieve the following prompt: `I want to use 3 ETH to purchase 10 of the best projects in: GameFi, NFTs, ZK, AI, and MEMEs. Please research the top projects, come up with a strategy, and purchase the tokens that look most promising. All of this should be on ETH mainnet.`

This prompt requires the agents to iteratively reason with themselves about what the best next step is, and previously it would exit without doing anything because it would request permission or clarification from the user.