### PR TITLE
chore: use mainnet for ens resolution

### DIFF
--- a/autotx/agents/SendTokensAgent.py
+++ b/autotx/agents/SendTokensAgent.py
@@ -47,13 +47,13 @@ class TransferTokenTool(AutoTxTool):
             amount = float(amount)
 
             web3 = load_w3()
-            receiver_addr = ETHAddress(receiver, web3)
-            token_address = ETHAddress(autotx.network.tokens[token.lower()], web3)
+            receiver_addr = ETHAddress(receiver)
+            token_address = ETHAddress(autotx.network.tokens[token.lower()])
 
             prepared_tx: PreparedTx | None = None
 
             if token_address.hex == NATIVE_TOKEN_ADDRESS:
-                tx = build_transfer_native(web3, ETHAddress(ADDRESS_ZERO, web3), receiver_addr, amount)
+                tx = build_transfer_native(web3, ETHAddress(ADDRESS_ZERO), receiver_addr, amount)
             else:
                 tx = build_transfer_erc20(web3, token_address, receiver_addr, amount)
 
@@ -81,8 +81,8 @@ class GetTokenBalanceTool(AutoTxTool):
             owner: Annotated[str, "The token owner's address or ENS domain"]
         ) -> float:
             web3 = load_w3()
-            owner_addr = ETHAddress(owner, web3)
-            token_address = ETHAddress(autotx.network.tokens[token.lower()], web3)
+            owner_addr = ETHAddress(owner)
+            token_address = ETHAddress(autotx.network.tokens[token.lower()])
             
             balance: float = 0
 

--- a/autotx/tests/agents/regression/token/test_tokens_regression.py
+++ b/autotx/tests/agents/regression/token/test_tokens_regression.py
@@ -43,7 +43,7 @@ def test_auto_tx_swap(configuration, auto_tx):
     (_, _, _, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    usdc_address = ETHAddress(network_info.tokens["usdc"], web3)
+    usdc_address = ETHAddress(network_info.tokens["usdc"])
 
     prompts = [
         "Buy 100 USDC with ETH",
@@ -117,8 +117,8 @@ def test_auto_tx_swap_and_send(configuration, auto_tx, test_accounts):
     (_, _, client, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    usdc_address = ETHAddress(network_info.tokens["usdc"], web3)
-    wbtc_address = ETHAddress(network_info.tokens["wbtc"], web3)
+    usdc_address = ETHAddress(network_info.tokens["usdc"])
+    wbtc_address = ETHAddress(network_info.tokens["wbtc"])
 
     receiver = test_accounts[0]
 

--- a/autotx/tests/agents/token/research/test_research_and_swap.py
+++ b/autotx/tests/agents/token/research/test_research_and_swap.py
@@ -5,7 +5,7 @@ from autotx.utils.ethereum.get_erc20_balance import get_erc20_balance
 def test_auto_tx_research_and_swap_meme_token(configuration, auto_tx):
     (_, _, _, manager) = configuration
     web3 = load_w3()
-    shib_address = ETHAddress(auto_tx.network.tokens["shib"], web3)
+    shib_address = ETHAddress(auto_tx.network.tokens["shib"])
     shib_balance_in_safe = manager.balance_of(shib_address)
     assert shib_balance_in_safe == 0
     prompt = (
@@ -18,10 +18,10 @@ def test_auto_tx_research_and_swap_meme_token(configuration, auto_tx):
 def test_auto_tx_research_swap_and_send_governance_token(configuration, auto_tx):
     (_, _, _, manager) = configuration
     web3 = load_w3()
-    uni_address = ETHAddress(auto_tx.network.tokens["uni"], web3)
+    uni_address = ETHAddress(auto_tx.network.tokens["uni"])
     uni_balance_in_safe = manager.balance_of(uni_address)
     assert uni_balance_in_safe == 0
-    receiver = ETHAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266", web3)
+    receiver = ETHAddress("0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266")
     prompt = f"Swap 1 ETH for the governance token with the largest market cap in ethereum mainnet and send 100 units of the bought token to {receiver}"
     auto_tx.run(prompt, non_interactive=True)
     uni_balance_in_safe = manager.balance_of(uni_address)

--- a/autotx/tests/agents/token/test_swap.py
+++ b/autotx/tests/agents/token/test_swap.py
@@ -6,7 +6,7 @@ def test_auto_tx_swap_with_non_default_token(configuration, auto_tx):
     (_, _, _, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    shib_address = ETHAddress(network_info.tokens["shib"], web3)
+    shib_address = ETHAddress(network_info.tokens["shib"])
 
     prompt = "Buy 100000 SHIB with ETH"
     balance = manager.balance_of(shib_address)
@@ -21,7 +21,7 @@ def test_auto_tx_swap_native(configuration, auto_tx):
     (_, _, _, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    usdc_address = ETHAddress(network_info.tokens["usdc"], web3)
+    usdc_address = ETHAddress(network_info.tokens["usdc"])
 
     prompt = "Buy 100 USDC with ETH"
     balance = manager.balance_of(usdc_address)
@@ -36,8 +36,8 @@ def test_auto_tx_swap_multiple(configuration, auto_tx):
     (_, _, _, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    usdc_address = ETHAddress(network_info.tokens["usdc"], web3)
-    wbtc_address = ETHAddress(network_info.tokens["wbtc"], web3)
+    usdc_address = ETHAddress(network_info.tokens["usdc"])
+    wbtc_address = ETHAddress(network_info.tokens["wbtc"])
 
     prompt = "Buy 1000 USDC with ETH and then buy WBTC with 500 USDC"
     usdc_balance = manager.balance_of(usdc_address)
@@ -52,9 +52,9 @@ def test_auto_tx_swap_triple(configuration, auto_tx):
     (_, _, _, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    usdc_address = ETHAddress(network_info.tokens["usdc"], web3)
-    uni_address = ETHAddress(network_info.tokens["uni"], web3)
-    wbtc_address = ETHAddress(network_info.tokens["wbtc"], web3)
+    usdc_address = ETHAddress(network_info.tokens["usdc"])
+    uni_address = ETHAddress(network_info.tokens["uni"])
+    wbtc_address = ETHAddress(network_info.tokens["wbtc"])
 
     prompt = "Buy 1 USDC, 0.5 UNI and 0.05 WBTC with ETH"
     usdc_balance = manager.balance_of(usdc_address)
@@ -71,8 +71,8 @@ def test_auto_tx_swap_complex_1(configuration, auto_tx): # This one is complex b
     (_, _, _, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    usdc_address = ETHAddress(network_info.tokens["usdc"], web3)
-    wbtc_address = ETHAddress(network_info.tokens["wbtc"], web3)
+    usdc_address = ETHAddress(network_info.tokens["usdc"])
+    wbtc_address = ETHAddress(network_info.tokens["wbtc"])
 
     prompt = "Swap ETH to 0.05 WBTC, then, swap WBTC to 1000 USDC"
     usdc_balance = manager.balance_of(usdc_address)
@@ -87,8 +87,8 @@ def test_auto_tx_swap_complex_2(configuration, auto_tx): # This one is complex b
     (_, _, _, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    usdc_address = ETHAddress(network_info.tokens["usdc"], web3)
-    wbtc_address = ETHAddress(network_info.tokens["wbtc"], web3)
+    usdc_address = ETHAddress(network_info.tokens["usdc"])
+    wbtc_address = ETHAddress(network_info.tokens["wbtc"])
 
     prompt = "Buy 1000 USDC with ETH, then sell the USDC to buy 0.001 WBTC"
     usdc_balance = manager.balance_of(usdc_address)

--- a/autotx/tests/agents/token/test_swap_and_send.py
+++ b/autotx/tests/agents/token/test_swap_and_send.py
@@ -6,7 +6,7 @@ def test_auto_tx_swap_and_send_simple(configuration, auto_tx, test_accounts):
     (_, _, client, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    wbtc_address = ETHAddress(network_info.tokens["wbtc"], web3)
+    wbtc_address = ETHAddress(network_info.tokens["wbtc"])
 
     receiver = test_accounts[0]
 
@@ -27,8 +27,8 @@ def test_auto_tx_swap_and_send_complex(configuration, auto_tx, test_accounts):
     (_, _, client, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    usdc_address = ETHAddress(network_info.tokens["usdc"], web3)
-    wbtc_address = ETHAddress(network_info.tokens["wbtc"], web3)
+    usdc_address = ETHAddress(network_info.tokens["usdc"])
+    wbtc_address = ETHAddress(network_info.tokens["wbtc"])
 
     receiver = test_accounts[0]
 
@@ -52,7 +52,7 @@ def test_auto_tx_send_and_swap_simple(configuration, auto_tx, test_accounts):
     (_, _, client, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    wbtc_address = ETHAddress(network_info.tokens["wbtc"], web3)
+    wbtc_address = ETHAddress(network_info.tokens["wbtc"])
 
     receiver = test_accounts[0]
 
@@ -77,8 +77,8 @@ def test_auto_tx_send_and_swap_complex(configuration, auto_tx, test_accounts):
     (_, _, client, manager) = configuration
     web3 = load_w3()
     network_info = NetworkInfo(web3.eth.chain_id)
-    usdc_address = ETHAddress(network_info.tokens["usdc"], web3)
-    wbtc_address = ETHAddress(network_info.tokens["wbtc"], web3)
+    usdc_address = ETHAddress(network_info.tokens["usdc"])
+    wbtc_address = ETHAddress(network_info.tokens["wbtc"])
 
     receiver_1 = test_accounts[0]
     receiver_2 = test_accounts[1]

--- a/autotx/utils/configuration.py
+++ b/autotx/utils/configuration.py
@@ -36,6 +36,6 @@ def get_configuration() -> tuple[ETHAddress | None, LocalAccount, EthereumClient
     client = EthereumClient(URI(rpc_url))
     agent = get_or_create_agent_account()
 
-    smart_account = ETHAddress(smart_account_addr, client.w3) if smart_account_addr else None
+    smart_account = ETHAddress(smart_account_addr) if smart_account_addr else None
 
     return (smart_account, agent, client)

--- a/autotx/utils/ethereum/SafeManager.py
+++ b/autotx/utils/ethereum/SafeManager.py
@@ -56,7 +56,7 @@ class SafeManager:
         self.safe = safe
         self.use_tx_service = False
         self.safe_nonce = None
-        self.address = ETHAddress(safe.address, self.web3)
+        self.address = ETHAddress(safe.address)
 
 
     @classmethod

--- a/autotx/utils/ethereum/deploy_multicall.py
+++ b/autotx/utils/ethereum/deploy_multicall.py
@@ -11,10 +11,10 @@ from .cache import cache
 def deploy_multicall(client: EthereumClient, account: LocalAccount) -> ETHAddress:
     multicall_address = os.getenv("MULTICALL_ADDRESS") 
     if multicall_address:
-        return ETHAddress(multicall_address, client.w3)
+        return ETHAddress(multicall_address)
     multicall_address = deploy(client, account)
     cache.write("multicall-address.txt", multicall_address)
-    return ETHAddress(multicall_address, client.w3)
+    return ETHAddress(multicall_address)
 
 def deploy(client: EthereumClient, account: LocalAccount) -> str:
     tx =  Multicall.deploy_contract(client, account) 

--- a/autotx/utils/ethereum/eth_address.py
+++ b/autotx/utils/ethereum/eth_address.py
@@ -1,19 +1,27 @@
-from eth_typing import ChecksumAddress
+from eth_typing import ChecksumAddress, HexStr
+from termcolor import cprint
 from web3 import Web3
-from web3._utils.empty import Empty
+
+from autotx.utils.ethereum.networks import MAINNET_DEFAULT_RPC
+
+
 class ETHAddress:
     hex: ChecksumAddress
     ens_domain: str | None
 
-    def __init__(self, hex_or_ens: str, web3: Web3):
+    def __init__(self, hex_or_ens: str):
         if hex_or_ens.endswith(".eth"):
-            self.hex = web3.ens.address(hex_or_ens) # type: ignore
+            web3 = Web3(MAINNET_DEFAULT_RPC)
+            address = web3.ens.address(hex_or_ens)  # type: ignore
+            if address == None:
+                raise ValueError(f"Invalid ENS: {hex_or_ens}")
+            self.hex = address
             self.ens_domain = hex_or_ens
         elif Web3.is_address(hex_or_ens):
             self.hex = Web3.to_checksum_address(hex_or_ens)
             self.ens_domain = None
         else:
             raise ValueError(f"Invalid address: {hex_or_ens}")
-        
+
     def __repr__(self) -> str:
         return f"{self.ens_domain}({self.hex})" if self.ens_domain else self.hex

--- a/autotx/utils/ethereum/helpers/fill_dev_account_with_erc20.py
+++ b/autotx/utils/ethereum/helpers/fill_dev_account_with_erc20.py
@@ -1,9 +1,12 @@
 from autotx.utils.ethereum import transfer_erc20
+from autotx.utils.ethereum.constants import NATIVE_TOKEN_ADDRESS
 from autotx.utils.ethereum.eth_address import ETHAddress
 from autotx.utils.ethereum.helpers.swap_from_eoa import swap
 from autotx.utils.ethereum.networks import NetworkInfo
 from eth_account.signers.local import LocalAccount
 from gnosis.eth import EthereumClient
+
+from autotx.utils.ethereum.uniswap.swap import SUPPORTED_UNISWAP_V3_NETWORKS
 
 
 def fill_dev_account_with_erc20(
@@ -12,18 +15,21 @@ def fill_dev_account_with_erc20(
     safe_address: ETHAddress,
     network_info: NetworkInfo,
 ) -> None:
+    if not network_info.chain_id in SUPPORTED_UNISWAP_V3_NETWORKS:
+        return
+
     tokens_to_transfer = {"usdc": 3500, "dai": 3500, "wbtc": 0.1}
-    eth_address = ETHAddress(network_info.tokens["eth"], client.w3)
+    native_token_address = ETHAddress(NATIVE_TOKEN_ADDRESS)
     for token in network_info.tokens:
         if token in tokens_to_transfer:
-            token_address = ETHAddress(network_info.tokens[token], client.w3)
+            token_address = ETHAddress(network_info.tokens[token])
             amount = tokens_to_transfer[token]
             swap(
                 client,
                 dev_account,
                 tokens_to_transfer[token],
-                eth_address,
-                ETHAddress(network_info.tokens[token], client.w3),
+                native_token_address,
+                token_address,
             )
             transfer_erc20(
                 client.w3, token_address, dev_account, safe_address, amount

--- a/autotx/utils/ethereum/helpers/show_address_balances.py
+++ b/autotx/utils/ethereum/helpers/show_address_balances.py
@@ -5,17 +5,26 @@ from autotx.utils.ethereum.constants import NATIVE_TOKEN_ADDRESS
 from autotx.utils.ethereum.networks import SUPPORTED_NETWORKS_CONFIGURATION_MAP, ChainId
 from autotx.utils.ethereum.eth_address import ETHAddress
 
-def show_address_balances(web3: Web3, network: ChainId, address: ETHAddress) -> None:
-    eth_balance = get_native_balance(web3, address)
-    print(f"ETH balance: {eth_balance}")
 
+def show_address_balances(web3: Web3, network: ChainId, address: ETHAddress) -> None:
     current_network = SUPPORTED_NETWORKS_CONFIGURATION_MAP.get(network)
-     
-    if current_network: 
+
+    if current_network:
+        native_token_symbol = next(
+            (
+                symbol
+                for symbol, address in current_network.default_tokens.items()
+                if address == NATIVE_TOKEN_ADDRESS
+            ),
+            None,
+        )
+        if native_token_symbol:
+            native_token_balance = get_native_balance(web3, address)
+            print(f"{native_token_symbol.upper()} balance: {native_token_balance}")
         for token in current_network.default_tokens:
             if current_network.default_tokens[token] == NATIVE_TOKEN_ADDRESS:
                 continue
-            token_address = ETHAddress(current_network.default_tokens[token], web3)
+            token_address = ETHAddress(current_network.default_tokens[token])
             balance = get_erc20_balance(web3, token_address, address)
 
             if balance > 0:

--- a/autotx/utils/ethereum/networks.py
+++ b/autotx/utils/ethereum/networks.py
@@ -1,12 +1,14 @@
 from dataclasses import dataclass
-from typing import Union, cast
+from typing import cast
 from gnosis.eth import EthereumNetwork
-from web3 import Web3
+from web3 import Web3, HTTPProvider
 
 from autotx.utils.ethereum.constants import NATIVE_TOKEN_ADDRESS
 from autotx.utils.ethereum.helpers.token_list import token_list
 
 ChainId = EthereumNetwork
+
+MAINNET_DEFAULT_RPC = HTTPProvider("https://mainnet.infura.io/v3/f1f688077be642c190ac9b28769daecf")
 
 class NetworkInfo:
     chain_id: ChainId


### PR DESCRIPTION
- now we use mainnet for ENS resolution
- `ETHAddress` class doesn't expect the `Web3` instance in constructor argument
- better support for native tokens and fill erc20 for L2 that have different native token/does not support uniswap

one thought is: should we explicitly add a warning if the address of the ENS is a smart contract? saying that the owner might not be the same in other network?