### PR TITLE
Smart wallet address abstraction

### DIFF
--- a/autotx/agents/DelegateResearchTokensAgent.py
+++ b/autotx/agents/DelegateResearchTokensAgent.py
@@ -113,7 +113,7 @@ class ResearchUserQuery(AutoTxTool):
                 research_agent, 
                 message=dedent(
                     f"""
-                    I am currently connected with the following wallet: {autotx.manager.address}, on network: {autotx.network.chain_id.name}
+                    I am currently connected with the following wallet: {autotx.wallet.address}, on network: {autotx.network.chain_id.name}
                     Tasks:
                     {tasks}
                     """

--- a/autotx/agents/SwapTokensAgent.py
+++ b/autotx/agents/SwapTokensAgent.py
@@ -5,6 +5,7 @@ from autotx import models
 from autotx.AutoTx import AutoTx
 from autotx.autotx_agent import AutoTxAgent
 from autotx.autotx_tool import AutoTxTool
+from autotx.utils.ethereum import load_w3
 from autotx.utils.ethereum.eth_address import ETHAddress
 from autotx.utils.ethereum.lifi.swap import SUPPORTED_NETWORKS_BY_LIFI, build_swap_transaction
 from autotx.utils.ethereum.networks import NetworkInfo
@@ -113,11 +114,11 @@ def swap(autotx: AutoTx, token_to_sell: str, token_to_buy: str) -> list[models.T
     )
 
     swap_transactions = build_swap_transaction(
-        autotx.manager.client,
+        load_w3(),
         Decimal(exact_amount),
         ETHAddress(token_in_address),
         ETHAddress(token_out_address),
-        autotx.manager.address,
+        autotx.wallet.address,
         is_exact_input,
         autotx.network.chain_id
     )

--- a/autotx/cli.py
+++ b/autotx/cli.py
@@ -37,7 +37,7 @@ def main() -> None:
 @click.option("-l", "--logs", type=click.Path(exists=False, file_okay=False, dir_okay=True), help="Path to the directory where logs will be stored.")
 @click.option("-r", "--max-rounds", type=int, help="Maximum number of rounds to run")
 @click.option("-c", "--cache", is_flag=True, help="Use cache for LLM requests")
-async def run(prompt: str | None, non_interactive: bool, verbose: bool, logs: str | None, max_rounds: int | None, cache: bool | None) -> None:
+def run(prompt: str | None, non_interactive: bool, verbose: bool, logs: str | None, max_rounds: int | None, cache: bool | None) -> None:
     print_autotx_info()
     
     if prompt == None:
@@ -45,19 +45,18 @@ async def run(prompt: str | None, non_interactive: bool, verbose: bool, logs: st
 
     (smart_account_addr, agent, client) = get_configuration()
 
-    (manager, network_info, web3) = setup_safe(smart_account_addr, agent, client)
+    (wallet, network_info, _web3) = setup_safe(smart_account_addr, agent, client, not non_interactive)
 
-    (get_llm_config, agents, logs_dir) = setup_agents(manager, logs, cache)
+    (get_llm_config, agents, logs_dir) = setup_agents(logs, cache)
 
     autotx = AutoTx(
-        manager,
+        wallet,
         network_info,
         agents,
-        Config(verbose=verbose, logs_dir=logs_dir, max_rounds=max_rounds),
-        get_llm_config=get_llm_config,
+        Config(verbose=verbose, get_llm_config=get_llm_config, logs_dir=logs_dir, max_rounds=max_rounds)
     )
 
-    result = await autotx.run(cast(str, prompt), non_interactive)
+    result = autotx.run(prompt, non_interactive)
 
     if result.total_cost_without_cache > 0:
         print(f"LLM cost: ${result.total_cost_without_cache:.2f} (Actual: ${result.total_cost_with_cache:.2f})")
@@ -65,7 +64,7 @@ async def run(prompt: str | None, non_interactive: bool, verbose: bool, logs: st
     if not smart_account_addr:
         print("=" * 50)
         print("Final smart account balances:")
-        show_address_balances(web3, network_info.chain_id, manager.address)
+        show_address_balances(web3, network_info.chain_id, wallet.address)
         print("=" * 50)
 
 @main.command()
@@ -74,10 +73,11 @@ async def run(prompt: str | None, non_interactive: bool, verbose: bool, logs: st
 @click.option("-r", "--max-rounds", type=int, help="Maximum number of rounds to run")
 @click.option("-c", "--cache", is_flag=True, help="Use cache for LLM requests")
 @click.option("-p", "--port", type=int, help="Port to run the server on")
-def serve(verbose: bool, logs: str | None, max_rounds: int | None, cache: bool | None, port: int | None) -> None:
+@click.option("-d", "--dev", is_flag=True, help="Run the server in development mode")
+def serve(verbose: bool, logs: str | None, max_rounds: int | None, cache: bool, port: int | None, dev: bool) -> None:
     print_autotx_info()
-    
-    start_server(verbose, logs, max_rounds, cache, port)
+
+    start_server(verbose, logs, max_rounds, cache, port, dev)
 
 @main.group()
 def agent() -> None:

--- a/autotx/cli.py
+++ b/autotx/cli.py
@@ -45,7 +45,7 @@ def run(prompt: str | None, non_interactive: bool, verbose: bool, logs: str | No
 
     (smart_account_addr, agent, client) = get_configuration()
 
-    (wallet, network_info, _web3) = setup_safe(smart_account_addr, agent, client, not non_interactive)
+    (wallet, network_info, web3) = setup_safe(smart_account_addr, agent, client, not non_interactive)
 
     (get_llm_config, agents, logs_dir) = setup_agents(logs, cache)
 
@@ -56,7 +56,7 @@ def run(prompt: str | None, non_interactive: bool, verbose: bool, logs: str | No
         Config(verbose=verbose, get_llm_config=get_llm_config, logs_dir=logs_dir, max_rounds=max_rounds)
     )
 
-    result = autotx.run(prompt, non_interactive)
+    result = autotx.run(cast(str, prompt), non_interactive)
 
     if result.total_cost_without_cache > 0:
         print(f"LLM cost: ${result.total_cost_without_cache:.2f} (Actual: ${result.total_cost_with_cache:.2f})")

--- a/autotx/models.py
+++ b/autotx/models.py
@@ -16,7 +16,7 @@ class TransactionBase(BaseModel):
     params: dict[str, Any]
 
 class SendTransaction(TransactionBase):
-    type: TransactionType = TransactionType.SEND
+    type: TransactionType
     receiver: str
     token_symbol: str
     token_address: str
@@ -26,6 +26,7 @@ class SendTransaction(TransactionBase):
         super().__init__(
             id="",
             task_id="",
+            type=TransactionType.SEND,
             token_symbol=token_symbol,
             token_address=token_address,
             amount=amount,
@@ -35,7 +36,7 @@ class SendTransaction(TransactionBase):
         )
 
 class ApproveTransaction(TransactionBase):
-    type: TransactionType = TransactionType.APPROVE
+    type: TransactionType
     token_symbol: str
     token_address: str
     amount: float
@@ -45,6 +46,7 @@ class ApproveTransaction(TransactionBase):
         super().__init__(
             id="",
             task_id="",
+            type=TransactionType.APPROVE,
             token_symbol=token_symbol,
             token_address=token_address,
             amount=amount,
@@ -54,7 +56,7 @@ class ApproveTransaction(TransactionBase):
         )
 
 class SwapTransaction(TransactionBase):
-    type: TransactionType = TransactionType.SWAP
+    type: TransactionType
     from_token_symbol: str
     to_token_symbol: str
     from_token_address: str
@@ -66,6 +68,7 @@ class SwapTransaction(TransactionBase):
         super().__init__(
             id="",
             task_id="",
+            type=TransactionType.SWAP,
             from_token_symbol=from_token_symbol,
             to_token_symbol=to_token_symbol,
             from_token_address=from_token_address,

--- a/autotx/models.py
+++ b/autotx/models.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from pydantic import BaseModel
-from typing import Any, List, Union
+from typing import Any, List, Optional, Union
 from datetime import datetime
 
 class TransactionType(str, Enum):
@@ -8,14 +8,14 @@ class TransactionType(str, Enum):
     APPROVE = "approve"
     SWAP = "swap"
 
-class BaseTransactionBase(BaseModel):
+class TransactionBase(BaseModel):
     type: TransactionType
     id: str
     task_id: str
     summary: str
     params: dict[str, Any]
 
-class SendTransaction(BaseTransactionBase):
+class SendTransaction(TransactionBase):
     type: TransactionType = TransactionType.SEND
     receiver: str
     token_symbol: str
@@ -34,7 +34,7 @@ class SendTransaction(BaseTransactionBase):
             summary=f"Transfer {amount} {token_symbol} to {receiver}",
         )
 
-class ApproveTransaction(BaseTransactionBase):
+class ApproveTransaction(TransactionBase):
     type: TransactionType = TransactionType.APPROVE
     token_symbol: str
     token_address: str
@@ -53,7 +53,7 @@ class ApproveTransaction(BaseTransactionBase):
             summary=f"Approve {amount} {token_symbol} to {spender}"
         )
 
-class SwapTransaction(BaseTransactionBase):
+class SwapTransaction(TransactionBase):
     type: TransactionType = TransactionType.SWAP
     from_token_symbol: str
     to_token_symbol: str
@@ -80,6 +80,7 @@ Transaction = Union[SendTransaction, ApproveTransaction, SwapTransaction]
 
 class TaskCreate(BaseModel):
     prompt: str
+    address: Optional[str] = None
 
 class Task(BaseModel):
     id: str

--- a/autotx/server.py
+++ b/autotx/server.py
@@ -13,9 +13,8 @@ from autotx import models, setup
 from autotx import models
 from autotx.AutoTx import AutoTx
 from autotx.AutoTx import Config as AutoTxConfig
-from autotx.autotx_agent import AutoTxAgent
 from autotx.utils.configuration import get_configuration
-from autotx.utils.ethereum import SafeManager, load_w3
+from autotx.utils.ethereum import load_w3
 from autotx.utils.ethereum.eth_address import ETHAddress
 from autotx.utils.ethereum.networks import NetworkInfo
 from autotx.wallets.api_smart_wallet import ApiSmartWallet
@@ -84,7 +83,7 @@ async def create_task(task: models.TaskCreate, background_tasks: BackgroundTasks
 
     wallet: SmartWallet
     if autotx_params.is_dev:
-        wallet = cast(SmartWallet, autotx_params.dev_wallet)
+        wallet = ApiSmartWallet(cast(SmartWallet, autotx_params.dev_wallet), task_id, tasks)
     else:
         wallet = ApiSmartWallet(ETHAddress(cast(str, task.address)), task_id, tasks)
 

--- a/autotx/server.py
+++ b/autotx/server.py
@@ -1,6 +1,6 @@
 import asyncio
 from datetime import datetime
-from typing import Any, Dict, List
+from typing import Any, Dict, List, cast
 import uuid
 from fastapi import APIRouter, FastAPI, BackgroundTasks, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -84,9 +84,9 @@ async def create_task(task: models.TaskCreate, background_tasks: BackgroundTasks
 
     wallet: SmartWallet
     if autotx_params.is_dev:
-        wallet = autotx_params.dev_wallet
+        wallet = cast(SmartWallet, autotx_params.dev_wallet)
     else:
-        wallet = ApiSmartWallet(ETHAddress(task.address), task_id, tasks)
+        wallet = ApiSmartWallet(ETHAddress(cast(str, task.address)), task_id, tasks)
 
     autotx = AutoTx(
         wallet,
@@ -147,7 +147,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-def setup_server(verbose: bool, logs: str | None, max_rounds: int | None, cache: bool | None, is_dev: bool) -> None:
+def setup_server(verbose: bool, logs: str | None, max_rounds: int | None, cache: bool, is_dev: bool) -> None:
     global tasks
     tasks = []
 

--- a/autotx/setup.py
+++ b/autotx/setup.py
@@ -19,12 +19,14 @@ from autotx.utils.ethereum.helpers.show_address_balances import show_address_bal
 from autotx.utils.ethereum.networks import NetworkInfo
 from autotx.utils.is_dev_env import is_dev_env
 from autotx.utils.ethereum.agent_account import get_or_create_agent_account
+from autotx.wallets.safe_smart_wallet import SafeSmartWallet
+from autotx.wallets.smart_wallet import SmartWallet
 
 def print_agent_address() -> None:
     acc = get_or_create_agent_account()
     print(f"Agent address: {acc.address}")
 
-def setup_safe(smart_account_addr: ETHAddress | None, agent: LocalAccount, client: EthereumClient) -> tuple[SafeManager, NetworkInfo, Web3]:
+def setup_safe(smart_account_addr: ETHAddress | None, agent: LocalAccount, client: EthereumClient, interactive: bool) -> tuple[SmartWallet, NetworkInfo, Web3]:
     web3 = client.w3
 
     chain_id = web3.eth.chain_id
@@ -65,9 +67,11 @@ def setup_safe(smart_account_addr: ETHAddress | None, agent: LocalAccount, clien
         show_address_balances(web3, network_info.chain_id, manager.address)
         print("=" * 50)
 
-    return (manager, network_info, web3)
+    wallet = SafeSmartWallet(manager, interactive)
 
-def setup_agents(manager: SafeManager, logs: str | None, cache: bool | None) -> tuple[Callable[[], Optional[Dict[str, Any]]], list[AutoTxAgent], str | None]:
+    return (wallet, network_info, web3)
+
+def setup_agents(logs: str | None, cache: bool | None) -> tuple[Callable[[], Optional[Dict[str, Any]]], list[AutoTxAgent], str | None]:
     now = datetime.now()
     now_str = now.strftime('%Y-%m-%d-%H-%M-%S-') + str(now.microsecond)
     logs_dir = os.path.join(logs, now_str) if logs is not None else None

--- a/autotx/tests/api/test_simple.py
+++ b/autotx/tests/api/test_simple.py
@@ -5,10 +5,14 @@ from fastapi.testclient import TestClient
 
 client = TestClient(app)
 
-def test_create_task():
-    server.setup_server(verbose=True, logs=None, max_rounds=None, cache=None)
+def test_create_task(configuration):
+    dev_account = configuration[0]
+    
+    server.setup_server(verbose=True, logs=None, max_rounds=None, cache=None, is_dev=False)
+    
     response = client.post("/api/v1/tasks", json={
         "prompt": "Send 1 ETH to vitalik.eth",
+        "address": dev_account.address,
     })
     assert response.status_code == 200
     data = response.json()

--- a/autotx/tests/api/test_simple.py
+++ b/autotx/tests/api/test_simple.py
@@ -8,7 +8,7 @@ client = TestClient(app)
 def test_create_task(configuration):
     dev_account = configuration[0]
     
-    server.setup_server(verbose=True, logs=None, max_rounds=None, cache=None, is_dev=False)
+    server.setup_server(verbose=True, logs=None, max_rounds=None, cache=False, is_dev=False)
     
     response = client.post("/api/v1/tasks", json={
         "prompt": "Send 1 ETH to vitalik.eth",

--- a/autotx/tests/conftest.py
+++ b/autotx/tests/conftest.py
@@ -1,6 +1,7 @@
 from dotenv import load_dotenv
 
 from autotx.utils.ethereum.helpers.swap_from_eoa import swap
+from autotx.wallets.safe_smart_wallet import SafeSmartWallet
 load_dotenv()
 
 from autotx.agents.DelegateResearchTokensAgent import DelegateResearchTokensAgent
@@ -55,15 +56,14 @@ def auto_tx(configuration):
     get_llm_config = lambda: { "cache_seed": None, "config_list": [{"model": OPENAI_MODEL_NAME, "api_key": OPENAI_API_KEY}]}
 
     return AutoTx(
-        manager, 
+        SafeSmartWallet(manager, interactive=False),
         network_info, 
         [
             SendTokensAgent(),
             SwapTokensAgent(),
             DelegateResearchTokensAgent()
         ], 
-        Config(verbose=True, logs_dir=None, log_costs=True, max_rounds=100), 
-        get_llm_config
+        Config(verbose=True, get_llm_config=get_llm_config, logs_dir=None, log_costs=True, max_rounds=100), 
     )
 
 @pytest.fixture()

--- a/autotx/tests/integration/test_swap.py
+++ b/autotx/tests/integration/test_swap.py
@@ -13,7 +13,7 @@ def test_buy_one_usdc(configuration):
     usdc_address = ETHAddress(network_info.tokens["usdc"])
     expected_usdc_amount = 1
     buy_usdc_with_eth_transaction = build_swap_transaction(
-        client,
+        client.w3,
         expected_usdc_amount,
         eth_address,
         usdc_address,
@@ -34,7 +34,7 @@ def test_buy_one_thousand_usdc(configuration):
     usdc_address = ETHAddress(network_info.tokens["usdc"])
     expected_usdc_amount = 1000
     buy_usdc_with_eth_transaction = build_swap_transaction(
-        client,
+        client.w3,
         expected_usdc_amount,
         eth_address,
         usdc_address,
@@ -58,7 +58,7 @@ def test_receive_native(configuration):
     safe_eth_balance = manager.balance_of()
     assert safe_eth_balance == 10
     buy_usdc_with_eth_transaction = build_swap_transaction(
-        client,
+        client.w3,
         5,
         eth_address,
         usdc_address,
@@ -72,7 +72,7 @@ def test_receive_native(configuration):
     assert safe_eth_balance == 5
 
     buy_eth_with_usdc_transaction = build_swap_transaction(
-        client,
+        client.w3,
         4,
         usdc_address,
         eth_address,
@@ -95,7 +95,7 @@ def test_buy_small_amount_wbtc_with_eth(configuration):
     wbtc_address = ETHAddress(network_info.tokens["wbtc"])
     expected_wbtc_amount = 0.01
     buy_wbtc_with_eth_transaction = build_swap_transaction(
-        client,
+        client.w3,
         Decimal(str(expected_wbtc_amount)),
         eth_address,
         wbtc_address,
@@ -116,7 +116,7 @@ def test_buy_big_amount_wbtc_with_eth(configuration):
     wbtc_address = ETHAddress(network_info.tokens["wbtc"])
     expected_wbtc_amount = 0.1
     buy_wbtc_with_eth_transaction = build_swap_transaction(
-        client,
+        client.w3,
         Decimal(str(expected_wbtc_amount)),
         eth_address,
         wbtc_address,
@@ -143,7 +143,7 @@ def test_swap_multiple_tokens(configuration):
     assert usdc_balance == 0
 
     sell_eth_for_usdc_transaction = build_swap_transaction(
-        client,
+        client.w3,
         1,
         eth_address,
         usdc_address,
@@ -160,7 +160,7 @@ def test_swap_multiple_tokens(configuration):
     assert wbtc_balance == 0
 
     buy_wbtc_with_usdc_transaction = build_swap_transaction(
-        client,
+        client.w3,
         0.01,
         usdc_address,
         wbtc_address,
@@ -180,7 +180,7 @@ def test_swap_multiple_tokens(configuration):
     assert shib_balance == 0
 
     sell_wbtc_for_shib = build_swap_transaction(
-        client,
+        client.w3,
         0.005,
         wbtc_address,
         shib_address,

--- a/autotx/utils/ethereum/helpers/swap_from_eoa.py
+++ b/autotx/utils/ethereum/helpers/swap_from_eoa.py
@@ -18,7 +18,7 @@ def swap(
     chain: ChainId,
 ) -> None:
     txs = build_swap_transaction(
-        client,
+        client.w3,
         Decimal(str(amount)),
         from_token,
         to_token,

--- a/autotx/utils/ethereum/lifi/swap.py
+++ b/autotx/utils/ethereum/lifi/swap.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from decimal import Decimal
 from typing import Any, cast
+
+from web3 import Web3
 from autotx import models
 from autotx.utils.ethereum.constants import GAS_PRICE_MULTIPLIER, NATIVE_TOKEN_ADDRESS
 from autotx.utils.ethereum.erc20_abi import ERC20_ABI
@@ -103,7 +105,7 @@ def get_quote(
 
 
 def build_swap_transaction(
-    ethereum_client: EthereumClient,
+    web3: Web3,
     amount: Decimal,
     token_in_address: ETHAddress,
     token_out_address: ETHAddress,
@@ -113,7 +115,7 @@ def build_swap_transaction(
 ) -> list[models.Transaction]:
     native_token_symbol = get_native_token_symbol(chain)
     token_in_is_native = token_in_address.hex == NATIVE_TOKEN_ADDRESS
-    token_in = ethereum_client.w3.eth.contract(
+    token_in = web3.eth.contract(
         address=token_in_address.hex, abi=ERC20_ABI
     )
     token_in_symbol = (
@@ -126,7 +128,7 @@ def build_swap_transaction(
     )
 
     token_out_is_native = token_out_address.hex == NATIVE_TOKEN_ADDRESS
-    token_out = ethereum_client.w3.eth.contract(
+    token_out = web3.eth.contract(
         address=token_out_address.hex, abi=ERC20_ABI
     )
     token_out_decimals = (
@@ -162,7 +164,7 @@ def build_swap_transaction(
                 {
                     "from": _from.hex,
                     "gasPrice": Wei(
-                        int(ethereum_client.w3.eth.gas_price * GAS_PRICE_MULTIPLIER)
+                        int(web3.eth.gas_price * GAS_PRICE_MULTIPLIER)
                     ),
                 }
             )

--- a/autotx/wallets/api_smart_wallet.py
+++ b/autotx/wallets/api_smart_wallet.py
@@ -1,10 +1,11 @@
 import uuid
 from autotx import models
+from autotx.utils.ethereum.eth_address import ETHAddress
 from autotx.wallets.smart_wallet import SmartWallet
 
 
 class ApiSmartWallet(SmartWallet):
-    def __init__(self, address: str, task_id: str, tasks: list[models.Task]):
+    def __init__(self, address: ETHAddress, task_id: str, tasks: list[models.Task]):
         super().__init__(address)
         self.task_id = task_id
         self.tasks = tasks
@@ -19,5 +20,5 @@ class ApiSmartWallet(SmartWallet):
 
         saved_task.transactions.extend(txs)
 
-    def on_transactions_ready(self, _txs: list[models.Transaction]) -> None:
-        pass
+    def on_transactions_ready(self, _txs: list[models.Transaction]) -> bool | str:
+        return True

--- a/autotx/wallets/api_smart_wallet.py
+++ b/autotx/wallets/api_smart_wallet.py
@@ -5,10 +5,16 @@ from autotx.wallets.smart_wallet import SmartWallet
 
 
 class ApiSmartWallet(SmartWallet):
-    def __init__(self, address: ETHAddress, task_id: str, tasks: list[models.Task]):
-        super().__init__(address)
+    external_wallet: SmartWallet | None
+
+    def __init__(self, wallet: ETHAddress | SmartWallet, task_id: str, tasks: list[models.Task]):
+        super().__init__(wallet.address if isinstance(wallet, SmartWallet) else wallet)
         self.task_id = task_id
         self.tasks = tasks
+        if isinstance(wallet, SmartWallet):
+            self.external_wallet = wallet
+        else:
+            self.external_wallet = None
 
     def on_transactions_prepared(self, txs: list[models.Transaction]) -> None:
         saved_task = next(filter(lambda x: x.id == self.task_id, self.tasks), None)
@@ -20,5 +26,11 @@ class ApiSmartWallet(SmartWallet):
 
         saved_task.transactions.extend(txs)
 
+        if self.external_wallet:
+            self.external_wallet.on_transactions_prepared(txs)
+
     def on_transactions_ready(self, _txs: list[models.Transaction]) -> bool | str:
+        if self.external_wallet:
+            return self.external_wallet.on_transactions_ready(_txs)
+
         return True

--- a/autotx/wallets/api_smart_wallet.py
+++ b/autotx/wallets/api_smart_wallet.py
@@ -1,0 +1,23 @@
+import uuid
+from autotx import models
+from autotx.wallets.smart_wallet import SmartWallet
+
+
+class ApiSmartWallet(SmartWallet):
+    def __init__(self, address: str, task_id: str, tasks: list[models.Task]):
+        super().__init__(address)
+        self.task_id = task_id
+        self.tasks = tasks
+
+    def on_transactions_prepared(self, txs: list[models.Transaction]) -> None:
+        saved_task = next(filter(lambda x: x.id == self.task_id, self.tasks), None)
+        if saved_task is None:
+            raise Exception("Task not found: " + self.task_id)
+        for tx in txs:
+            tx.id = str(uuid.uuid4())
+            tx.task_id = self.task_id
+
+        saved_task.transactions.extend(txs)
+
+    def on_transactions_ready(self, _txs: list[models.Transaction]) -> None:
+        pass

--- a/autotx/wallets/safe_smart_wallet.py
+++ b/autotx/wallets/safe_smart_wallet.py
@@ -16,5 +16,5 @@ class SafeSmartWallet(SmartWallet):
     def on_transactions_prepared(self, txs: list[models.Transaction]) -> None:
         pass
 
-    def on_transactions_ready(self, txs: list[models.Transaction]) -> None:
-        self.manager.send_tx_batch(txs, self.interactive)
+    def on_transactions_ready(self, txs: list[models.Transaction]) -> bool | str:
+        return self.manager.send_tx_batch(txs, self.interactive)

--- a/autotx/wallets/safe_smart_wallet.py
+++ b/autotx/wallets/safe_smart_wallet.py
@@ -1,0 +1,20 @@
+from autotx import models
+from autotx.utils.ethereum import SafeManager
+from autotx.wallets.smart_wallet import SmartWallet
+
+
+class SafeSmartWallet(SmartWallet):
+    manager: SafeManager
+    interactive: bool
+
+    def __init__(self, manager: SafeManager, interactive: bool):
+        super().__init__(manager.address)
+
+        self.manager = manager
+        self.interactive = interactive
+
+    def on_transactions_prepared(self, txs: list[models.Transaction]) -> None:
+        pass
+
+    def on_transactions_ready(self, txs: list[models.Transaction]) -> None:
+        self.manager.send_tx_batch(txs, self.interactive)

--- a/autotx/wallets/smart_wallet.py
+++ b/autotx/wallets/smart_wallet.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 from autotx import models
 from autotx.utils.ethereum.eth_address import ETHAddress
 
@@ -9,5 +10,6 @@ class SmartWallet:
     def on_transactions_prepared(self, txs: list[models.Transaction]) -> None:
         pass
 
-    def on_transactions_ready(self, txs: list[models.Transaction]) -> None:
+    @abstractmethod
+    def on_transactions_ready(self, txs: list[models.Transaction]) -> bool | str: # True if sent, False if declined, str if feedback
         pass

--- a/autotx/wallets/smart_wallet.py
+++ b/autotx/wallets/smart_wallet.py
@@ -1,0 +1,13 @@
+from autotx import models
+from autotx.utils.ethereum.eth_address import ETHAddress
+
+
+class SmartWallet:
+    def __init__(self, address: ETHAddress):
+        self.address = address
+
+    def on_transactions_prepared(self, txs: list[models.Transaction]) -> None:
+        pass
+
+    def on_transactions_ready(self, txs: list[models.Transaction]) -> None:
+        pass


### PR DESCRIPTION
API mode now has dev and non-dev mode.
`-d --dev` to start api in dev mode
In dev mode the safe smart wallet is used (either the SMART_ACCOUNT_ADDRESS or a dev_account)
In non-dev mode (default) the address is expected to be provided when POSTing to the `/api/v1/task` endpoint
Both async (`await autotx.a_run`) and sync (`autotx.run`) modes of autotx run are supported
